### PR TITLE
Properly handle 404s for locations containing a dot

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,9 +1,14 @@
 server {
   listen 80;
 
+  root /usr/share/nginx/html;
+  include /etc/nginx/mime.types;
+
   location / {
-    root /usr/share/nginx/html/;
-    include /etc/nginx/mime.types;
     try_files $uri $uri/ /index.html;
+  }
+
+  location ~ \. {
+    try_files $uri $uri/ =404;
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10835147/159143846-a8792bbb-0e48-4b4c-8d8f-5f424b853a22.png)

![image](https://user-images.githubusercontent.com/10835147/159143861-4942a8ac-546e-4fca-8a06-8c85b1cac8d9.png)

![image](https://user-images.githubusercontent.com/10835147/159143852-a7e3b210-330e-45b8-abb7-6f7aa0897ac1.png)

![image](https://user-images.githubusercontent.com/10835147/159143855-fd50bb73-5efc-49b4-a27f-63a3aa997bf3.png)

nginx location blocks don't match query strings so requests like /something?something=1.23 will still be handled by the index.html file.