### PR TITLE
Create [Throttle] attribute

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: dotnet restore
 
       - name: Run analyzer
-        run: dotnet format --severity info --verify-no-changes --no-restore
+        run: dotnet format CbtBackend.sln --severity info --verify-no-changes --no-restore
 
       - name: Build
         run: dotnet build --no-restore

--- a/backend/Attributes/ThrottleAttribute.cs
+++ b/backend/Attributes/ThrottleAttribute.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace CbtBackend.Attributes;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public class Throttle : ActionFilterAttribute {
+    private readonly int limit;
+    private readonly double durationMinutes;
+
+    public bool ByAction { get; set; } = true;
+    public bool ByIpAddress { get; set; } = true;
+
+    private static readonly ConcurrentDictionary<string, List<DateTime>> History = new();
+
+    public Throttle(int limit, double durationMinutes) {
+        this.limit = limit;
+        this.durationMinutes = durationMinutes;
+    }
+
+    public override void OnActionExecuting(ActionExecutingContext context) {
+        base.OnActionExecuting(context);
+
+        var key = BuildKey(context);
+        if (key is null)
+        {
+            // failed to build the key, no throttle will be applied
+            // TODO: log it (warning)
+            return;
+        }
+
+        if (!History.ContainsKey(key)) {
+            History.TryAdd(key, new List<DateTime>());
+        }
+
+        var list = History[key];
+        lock (list) {
+            var now = DateTime.Now;
+            var validSince = now - TimeSpan.FromMinutes(durationMinutes);
+            var bs = list.BinarySearch(validSince);
+
+            if (bs < 0) {
+                bs = ~bs;
+            }
+
+            if (bs > 0) {
+                list.RemoveRange(0, bs);
+            }
+
+            if (list.Count < limit) {
+                list.Add(now);
+            } else {
+                ResultRateLimit(context);
+            }
+        }
+    }
+
+    private string? BuildKey(ActionExecutingContext context) {
+        var sb = new StringBuilder();
+
+        if (ByAction) {
+            sb.Append(context.ActionDescriptor.Id);
+            sb.Append(';');
+        }
+
+        if (ByIpAddress) {
+            if (context.HttpContext.Connection.RemoteIpAddress is null) {
+                return null;
+            }
+
+            sb.Append(context.HttpContext.Connection.RemoteIpAddress);
+            sb.Append(';');
+        }
+
+        return sb.ToString();
+    }
+
+    private static void ResultRateLimit(ActionExecutingContext context) {
+        context.Result = new StatusCodeResult((int)HttpStatusCode.TooManyRequests);
+    }
+}

--- a/backend/Attributes/ThrottleAttribute.cs
+++ b/backend/Attributes/ThrottleAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Text;
 using Microsoft.AspNetCore.Mvc;
@@ -25,8 +25,7 @@ public class Throttle : ActionFilterAttribute {
         base.OnActionExecuting(context);
 
         var key = BuildKey(context);
-        if (key is null)
-        {
+        if (key is null) {
             // failed to build the key, no throttle will be applied
             // TODO: log it (warning)
             return;

--- a/backend/CbtBackend.sln
+++ b/backend/CbtBackend.sln
@@ -1,0 +1,16 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{0A9DD490-84FC-46CF-8308-4C9EE5F86DCD}") = "CbtBackend", "CbtBackend.csproj", "{0C369C35-BB62-429B-9963-90DE9B9F5B6E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0C369C35-BB62-429B-9963-90DE9B9F5B6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C369C35-BB62-429B-9963-90DE9B9F5B6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C369C35-BB62-429B-9963-90DE9B9F5B6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C369C35-BB62-429B-9963-90DE9B9F5B6E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/backend/Controllers/UsersController.cs
+++ b/backend/Controllers/UsersController.cs
@@ -1,3 +1,4 @@
+using CbtBackend.Attributes;
 using CbtBackend.Contracts;
 using CbtBackend.Entities;
 using Microsoft.AspNetCore.Authorization;
@@ -24,6 +25,7 @@ public class UsersController : ControllerBase {
 
     [AllowAnonymous]
     [HttpPost(ApiRoutes.User.Login)]
+    [Throttle(5, 1)]
     public async Task<IActionResult> Login([FromQuery(Name = "email")] string email, [FromQuery(Name = "password")] string password) {
         logger.LogDebug("Authenticating user with data [email = {email}, password = {password}]", email, password);
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,6 +26,6 @@ USER 1000:1000
 COPY --from=build --chown=1000:1000 /app/build .
 
 EXPOSE 80
-VOLUME [ "/keys" ]
+VOLUME [ "/app/keys" ]
 
 ENTRYPOINT [ "./CbtBackend" ]

--- a/backend/Utilities.cs
+++ b/backend/Utilities.cs
@@ -1,0 +1,7 @@
+﻿namespace CbtBackend;
+
+public static class Utilities {
+    public static bool IsDocker() {
+        return Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == "true";
+    }
+}

--- a/backend/Utilities.cs
+++ b/backend/Utilities.cs
@@ -1,4 +1,4 @@
-﻿namespace CbtBackend;
+namespace CbtBackend;
 
 public static class Utilities {
     public static bool IsDocker() {


### PR DESCRIPTION
Closes #141.

It's been configured to allow 5 requests per 1 minute as it does not respect valid/invalid login attempts. It just hooks on every request. One could override `OnResultExecuted` and make the algorithm more sophisticated by validating the return status codes. But... it's just a school project.

![1649263823_chrome__](https://user-images.githubusercontent.com/10835147/162026652-b97a3edc-f091-4624-bb42-a27e8e268230.gif)

Some other small changes include:
* Create solution (.sln) file *(Rider struggles without it)*.
* Correct docker volume path from `/keys` to `/app/keys`.
* Respect `X-Forwaded-*` headers while in Docker for the `[Throttle]` to work properly.

