### PR TITLE
fix protection on /user endpoints

### DIFF
--- a/backend/CbtBackend.Test/AuthenticationTests.cs
+++ b/backend/CbtBackend.Test/AuthenticationTests.cs
@@ -16,6 +16,6 @@ public class AuthenticationTests : IClassFixture<CustomWebApplicationFactory<Sta
         var client = factory.CreateClient();
         var res = await client.GetAsync("/" + Contracts.ApiRoutes.User.Login);
 
-        Assert.Equal(HttpStatusCode.Forbidden, res.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
     }
 }

--- a/backend/CbtBackend/Controllers/UsersController.cs
+++ b/backend/CbtBackend/Controllers/UsersController.cs
@@ -49,6 +49,7 @@ public class UsersController : ControllerBase {
         return Ok();
     }
 
+    [Authorize(Roles = UserRoles.UserRead)]
     [HttpGet(ApiRoutes.User.GetAll)]
     public async Task<IActionResult> GetAllUsers() {
         var users = await userService.GetAllUsersAsync();
@@ -56,6 +57,7 @@ public class UsersController : ControllerBase {
         return Ok(users.Select(e => new UserDTO(e)).ToList());
     }
 
+    [Authorize(Roles = UserRoles.UserRead)]
     [HttpGet(ApiRoutes.User.GetByEmail)]
     public async Task<IActionResult> GetUserByEmail([FromRoute] string login) {
         var user = await userManager.FindByEmailAsync(login);
@@ -67,6 +69,7 @@ public class UsersController : ControllerBase {
         return Ok(new UserDTO(user));
     }
 
+    [Authorize(Roles = UserRoles.UserWrite + "," + UserRoles.UserRead)]
     [HttpPut(ApiRoutes.User.UpdateByEmail)]
     public async Task<IActionResult> UpdateUser([FromRoute] string login, [FromBody] UserUpdateRequest userRequest) {
         logger.LogDebug("Updating user with data [email = {login}, password = {password}], age= {age}, gender= {gender}, banned= {banned}, userStatus= {status}",
@@ -84,6 +87,7 @@ public class UsersController : ControllerBase {
         }
     }
 
+    [Authorize(Roles = UserRoles.UserWrite + "," + UserRoles.UserRead)]
     [HttpDelete(ApiRoutes.User.DeleteByEmail)]
     public async Task<IActionResult> DeleteUser([FromRoute] string login) {
         logger.LogDebug("Deleting user with data [email = {login}]", login);

--- a/backend/CbtBackend/Startup.cs
+++ b/backend/CbtBackend/Startup.cs
@@ -75,7 +75,7 @@ public class Startup {
                 };
             });
 
-            services.AddIdentity<User, IdentityRole>(options => {
+            services.AddIdentityCore<User>(options => {
                 options.User.RequireUniqueEmail = false;
                 options.Password.RequireDigit = false;
                 options.Password.RequireLowercase = false;
@@ -83,6 +83,7 @@ public class Startup {
                 options.Password.RequireUppercase = false;
                 options.Lockout.AllowedForNewUsers = false;
             })
+            .AddRoles<IdentityRole>()
             .AddEntityFrameworkStores<CbtDbContext>()
             .AddDefaultTokenProviders();
         }


### PR DESCRIPTION
in this branch:

- user endpoints were protected with roles
- switched `AddIdentity` to `AddIdentityCore` (this is a version of `AddIdentity` that does not introduce stateful auth with cookies so it fixes a bug where instead of returning `401` a redirection is performed instead)