### PR TITLE
Throttle bypass for localhost requests + Optional global bypass

### DIFF
--- a/backend/CbtBackend/Attributes/ThrottleAttribute.cs
+++ b/backend/CbtBackend/Attributes/ThrottleAttribute.cs
@@ -9,6 +9,8 @@ namespace CbtBackend.Attributes;
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public class Throttle : ActionFilterAttribute {
+    public static bool Bypass = false;
+
     private readonly int limit;
     private readonly double durationMinutes;
 
@@ -25,6 +27,10 @@ public class Throttle : ActionFilterAttribute {
 
     public override void OnActionExecuting(ActionExecutingContext context) {
         base.OnActionExecuting(context);
+
+        if (Bypass) {
+            return;
+        }
 
         if (BypassLocalHost && context.HttpContext.Connection.RemoteIpAddress is {
                 AddressFamily: AddressFamily.InterNetwork or AddressFamily.InterNetworkV6

--- a/backend/CbtBackend/Startup.cs
+++ b/backend/CbtBackend/Startup.cs
@@ -1,3 +1,5 @@
+using CbtBackend.Attributes;
+
 namespace CbtBackend;
 
 using System.Text;
@@ -89,14 +91,20 @@ public class Startup {
             .AddEntityFrameworkStores<CbtDbContext>()
             .AddDefaultTokenProviders();
         }
-
     }
 
     public void Configure(
         IApplicationBuilder app,
         IWebHostEnvironment env,
+        ILogger<Startup> logger,
         CbtDbContext dbContext,
         RoleManager<Role> roleManager) {
+        // Throttle configuration
+        if (Configuration.GetValue("Throttle:Bypass", false)) {
+            logger.LogWarning("Throttle is set to BYPASS mode");
+            Throttle.Bypass = true;
+        }
+
         if (!dbContext.Database.IsInMemory()) {
             dbContext.Database.Migrate();
         }

--- a/backend/CbtBackend/appsettings.Development.json
+++ b/backend/CbtBackend/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+
+  "Throttle": {
+    "Bypass": true
   }
 }

--- a/backend/CbtBackend/appsettings.json
+++ b/backend/CbtBackend/appsettings.json
@@ -6,6 +6,10 @@
     }
   },
 
+  "Throttle": {
+    "Bypass": false
+  },
+
   "Jwt": {
     "Key": "meguminmeguminmeguminmegumin",
     "Issuer": "localhost",


### PR DESCRIPTION
You can enable bypass mode globally by adjusting the configuration.

Enabled by default in `appsettings.Development.json`.